### PR TITLE
Support for multiple pgpool daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ This works just as the above plugin, but we look for the string "idle in transac
 ## Access rights to PID file
 Note that you should give a+r access rights to pgpool PID file
 
-    chmod a+x /var/run/pgpool/pgpool.pid
+    chmod a+r /var/run/pgpool/pgpool.pid

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If `env.pcppath` is not specified, the plugin executes `/usr/bin/pcp_pool_path`.
     env.user  pooladm
     env.userpwd  foobar123
     env.pcppath  /path/to/pcp_pool_status
-
+    env.pid_file /var/run/pgpool/pgpool.pid 
 
 # Requirements
 
@@ -51,3 +51,6 @@ We then just count the number of occurrences and plot the value.
 
 This works just as the above plugin, but we look for the string "idle in transaction".
 
+Note that you should give a+r access rights to pgpool PID file
+
+    chmod a+x /var/run/pgpool/pgpool.pid

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ We then just count the number of occurrences and plot the value.
 
 This works just as the above plugin, but we look for the string "idle in transaction".
 
+## Access rights to PID file
 Note that you should give a+r access rights to pgpool PID file
 
     chmod a+x /var/run/pgpool/pgpool.pid

--- a/pgpool_connections
+++ b/pgpool_connections
@@ -14,6 +14,12 @@ user = os.environ['user']
 userpwd = os.environ['userpwd']
 timeout = 5
 pcppath = os.environ.get( 'pcppath', '/usr/bin/pcp_pool_status' )
+pid_file = os.environ.get( 'pid_file', '' )
+parent_pid = 0
+
+if ( pid_file != '' ):
+  from subprocess import call
+  parent_pid = int(open(pid_file, 'r').read().split(b'\0',1)[0])
 
 if len(sys.argv) == 2 and sys.argv[1] == "autoconf":
     print 'yes'
@@ -38,9 +44,9 @@ else:
     pl = psutil.process_iter()
     
     for item in pl:
-        if ("wait for connection request" in str(item) and not "PCP" in str(item)):
+        if ((item.ppid == parent_pid or parent_pid == 0) and "wait for connection request" in str(item) and not "PCP" in str(item)):
             waitCount += 1
-        elif ("idle in transaction" in str(item) and not "PCP" in str(item)):
+        elif ((item.ppid == parent_pid or parent_pid == 0) and "idle in transaction" in str(item) and not "PCP" in str(item)):
             idleCount += 1
     
     if sys.version_info < ( 2, 7, 0 ):


### PR DESCRIPTION
If you have several running pgpool process on your server then "wait" and "idle" params will show incorrect values: a summ for all pgpool daemons.

"pid_file" option allow to specify which process tree we should scan.