### PR TITLE
Use .pcppass for identification and call to pcp_pool_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ The plugin plots three values:
 
 # Configuration
 
-In order to authenticate to pgpool, we need to provide the credentials for `pcp_pool_status` in plugins.conf:
+In order to authenticate to pgpool, we need to provide the username for `pcp_pool_status` in plugins.conf and set [.pcppass](http://www.pgpool.net/docs/pgpool-II-3.5.4/doc/pgpool-en.html#password_file) for postgres user.
 If `env.pcppath` is not specified, the plugin executes `/usr/bin/pcp_pool_path`.
 
     [pgpool_*]
+    user   postgres
     env.host  MyDBServer
     env.port  9898
     env.user  pooladm
-    env.userpwd  foobar123
     env.pcppath  /path/to/pcp_pool_status
     env.pid_file /var/run/pgpool/pgpool.pid 
 
@@ -50,8 +50,3 @@ We then just count the number of occurrences and plot the value.
 ## Idle connections
 
 This works just as the above plugin, but we look for the string "idle in transaction".
-
-## Access rights to PID file
-Note that you should give a+r access rights to pgpool PID file
-
-    chmod a+r /var/run/pgpool/pgpool.pid

--- a/pgpool_connections
+++ b/pgpool_connections
@@ -27,8 +27,6 @@ def processname(process):
 host = os.environ['host']
 port = os.environ['port']
 user = os.environ['user']
-userpwd = os.environ['userpwd']
-timeout = 5
 pcppath = os.environ.get( 'pcppath', '/usr/bin/pcp_pool_status' )
 pid_file = os.environ.get( 'pid_file', '' )
 parent_pid = 0
@@ -67,10 +65,10 @@ else:
             idleCount += 1
     
     if sys.version_info < ( 2, 7, 0 ):
-        pcpobject = subprocess.Popen( [ pcppath, str(timeout), host, port, user, userpwd ], stdout=subprocess.PIPE )
+        pcpobject = subprocess.Popen( [ pcppath, "-h", host, "-p", port, "-U", user, "-w" ], stdout=subprocess.PIPE )
         pcpstatus = pcpobject.communicate()[0]
     else:
-        pcpstatus = subprocess.check_output(["pcp_pool_status", str(timeout), host, port, user, userpwd])
+        pcpstatus = subprocess.check_output(["pcp_pool_status", "-h", host, "-p", port, "-U", user, "-w"])
 
     match = re.search(r'(name\s+:\s+num_init_children)\nvalue:\s(\d+)', pcpstatus)
     if match:


### PR DESCRIPTION
Changed to .pcppass auth and pcp_pool_status now requires parameters.
These changes were required for the plugin to work under latest Debian.