### PR TITLE
 get correct processname and ppid

### DIFF
--- a/pgpool_connections
+++ b/pgpool_connections
@@ -20,7 +20,8 @@ def processname(process):
         else:
             return process.name
     else:
-        return cmdline[0]
+        #return cmdline[0]
+	return " ".join(cmdline)
 
 
 # Get variables from config
@@ -59,9 +60,9 @@ else:
     
     for item in pl:
         procname = processname(item)
-        if ((item.ppid == parent_pid or parent_pid == 0) and "wait for connection request" in procname and not "PCP" in procname):
+        if ((item.ppid() == parent_pid or parent_pid == 0) and "wait for connection request" in procname and not "PCP" in procname):
             waitCount += 1
-        elif ((item.ppid == parent_pid or parent_pid == 0) and "idle in transaction" in procname and not "PCP" in procname):
+        elif ((item.ppid() == parent_pid or parent_pid == 0) and "idle in transaction" in procname and not "PCP" in procname):
             idleCount += 1
     
     if sys.version_info < ( 2, 7, 0 ):

--- a/pgpool_connections
+++ b/pgpool_connections
@@ -62,7 +62,7 @@ else:
         procname = processname(item)
         if ((item.ppid() == parent_pid or parent_pid == 0) and "wait for connection request" in procname and not "PCP" in procname):
             waitCount += 1
-        elif ((item.ppid() == parent_pid or parent_pid == 0) and "idle in transaction" in procname and not "PCP" in procname):
+        elif ((item.ppid() == parent_pid or parent_pid == 0) and "idle" in procname and not "PCP" in procname):
             idleCount += 1
     
     if sys.version_info < ( 2, 7, 0 ):


### PR DESCRIPTION
under  linux, dump original return value of processname() 
cmdline is
['pgpool:', 'wait', 'for', 'connection', 'request']
so the waitCount is always 0.

now idle line look like this
10838 ?        Ss     0:00 postgres: docker testdb 127.0.0.1(43348) idle
16866 ?        S      0:00 pgpool: docker testdb localhost(45954) idle
so idleCount is always 0.

this PR fix them.





